### PR TITLE
parameters for API

### DIFF
--- a/src/app/services/translation.service.ts
+++ b/src/app/services/translation.service.ts
@@ -22,12 +22,15 @@ export class TranslationService {
   }
 
   translate(language: string, text: string, target: string) {
+    language = language.split('-')[0];
+    target = target.split('-')[0];
     return this.http.post(
       `${this.baseUrl}?key=${this.settings.googleTranslateApiKey}`,
       {
         target,
         source: language,
         q: text,
+        format: 'text'
       })
       .pipe(
         switchMap(response => of(_.get(response, 'data.translations[0].translatedText', '')))


### PR DESCRIPTION
The google translate API does not accept the parameter `en-US` and `es-ES`, it was necessary to pass only the first part of the acronym of the language, doing the split and passing only `en` and `es`.

## Error request
![image](https://user-images.githubusercontent.com/6785407/49945749-aafc8d80-fed4-11e8-8a51-7c48ed0f521b.png)

## Correct requisition
![image](https://user-images.githubusercontent.com/6785407/49945794-c8315c00-fed4-11e8-812d-7372dc827327.png)
