### PR TITLE
Make collapsing an element a faster by only collapsing the already ex…

### DIFF
--- a/src/folder/views/Folder/compositions/tree.ts
+++ b/src/folder/views/Folder/compositions/tree.ts
@@ -115,12 +115,17 @@ export default function useTree(
 
   function filterItems(filter: string) {
     return (treeItems.value ?? []).filter(it => {
-      return filterByKey(it, filter) || filterByValue(it, filter);
+      return filterByKey(it, filter) || filterByPath(it, filter) || filterByValue(it, filter);
     });
   }
 
   function filterByKey(item: TreeItem, filter: string) {
     return item.label.toLowerCase().includes(filter);
+  }
+
+  function filterByPath(item: TreeItem, filter: string) {
+      return filter.includes('.') && (item.path.filter(p => typeof p === "string")
+      .join('.').replace('items.data.', '').toLowerCase().includes(filter));
   }
 
   function filterByValue(item: TreeItem, filter: string) {

--- a/src/folder/views/Folder/compositions/tree.ts
+++ b/src/folder/views/Folder/compositions/tree.ts
@@ -48,14 +48,16 @@ export default function useTree(
   }
 
   function dropExpandedChildren(id: string) {
-    expandedItems = expandedItems.filter(it => it !== id);
+    if (expandedItems.find(it => it === id) != null) {
+      expandedItems = expandedItems.filter((it) => it !== id);
 
-    const children = (filteredTreeItems.value ?? [])
-      .filter(it => it.parent === id)
-      .map(it => it.id);
+      const children = (filteredTreeItems.value ?? [])
+        .filter(it => it.parent === id)
+        .map(it => it.id);
 
-    for (let i = 0; i < children.length; ++i) {
-      dropExpandedChildren(children[i]);
+      for (let i = 0; i < children.length; ++i) {
+        dropExpandedChildren(children[i]);
+      }
     }
   }
 

--- a/src/folder/views/Folder/compositions/tree.ts
+++ b/src/folder/views/Folder/compositions/tree.ts
@@ -48,7 +48,7 @@ export default function useTree(
   }
 
   function dropExpandedChildren(id: string) {
-    if (expandedItems.find(it => it === id) != null) {
+    if (expandedItems.find(it => it === id)) {
       expandedItems = expandedItems.filter((it) => it !== id);
 
       const children = (filteredTreeItems.value ?? [])
@@ -124,8 +124,11 @@ export default function useTree(
   }
 
   function filterByPath(item: TreeItem, filter: string) {
-      return filter.includes('.') && (item.path.filter(p => typeof p === "string")
-      .join('.').replace('items.data.', '').toLowerCase().includes(filter));
+      return filter.includes('.') && 
+      (item.path.filter(p => typeof p === 'string')
+      .join('.')
+      .replace('items.data.', '')
+      .toLowerCase().includes(filter));
   }
 
   function filterByValue(item: TreeItem, filter: string) {


### PR DESCRIPTION
When the element is collapsed it loops through all the children which is very costly specially for very big trees, but instead you should only loop through the children that are already in the expandedItems list, this saves a lot of time.